### PR TITLE
Make sure `buffer` is callable before calling it

### DIFF
--- a/packages/node_modules/pouchdb-adapter-http/src/index.js
+++ b/packages/node_modules/pouchdb-adapter-http/src/index.js
@@ -619,7 +619,7 @@ function HttpPouch(opts, callback) {
       if (!response.ok) {
         throw response;
       } else {
-        if (typeof process !== 'undefined' && !process.browser) {
+        if (typeof process !== 'undefined' && !process.browser && typeof response.buffer === 'function') {
           return response.buffer();
         } else {
           /* istanbul ignore next */


### PR DESCRIPTION
See https://github.com/pouchdb/pouchdb/issues/7836#issuecomment-544228459 for details on this bug.